### PR TITLE
fixed db open error. this patch contains a dirty workaround.

### DIFF
--- a/src/gui/dao.c
+++ b/src/gui/dao.c
@@ -76,10 +76,20 @@ static gint create_tables(sqlite3 *db)
 
 sqlite3* db_open()
 {
+    /* get config dir path. you needn't to free the home dir buffer. it's static */
+    /* maybe this patch it's dirty. if you think so please change this. */
+    GString *dbpath = g_string_new (g_get_home_dir ());
+    g_string_append (dbpath, "/.gtkqq/gtkqq.db");
+    
+    /* -- */
     sqlite3 *db;
-    g_debug("Open db connection to "CONFIGDIR"gtkqq.db (%s, %d)"
+    g_debug("Open db connection (%s, %d)"
                                         , __FILE__, __LINE__);
-    gint retcode = sqlite3_open(CONFIGDIR"gtkqq.db", &db);
+    gint retcode = sqlite3_open(dbpath->str, &db);
+    
+    /* {{ free GString */
+    g_string_free (dbpath, TRUE);
+    /* }} */
     if(retcode != SQLITE_OK){
         if(retcode == SQLITE_NOMEM){
             g_error("Open database error. no memory. (%s, %d)", __FILE__, __LINE__);


### PR DESCRIPTION
this is the brother patch for https://github.com/kernelhcy/gtkqq/pull/21 ~

well, if you use the version within the patch above, then you'll get the error:
DEBUG : Open db connection to /root/.gtkqq/gtkqq.db (dao.c, 81)

*\* ERROR **: Open database error. unable to open database file (dao.c, 89)
zsh: trace trap  gtkqq

This patch maybe can fix this (i haven't tried.)
