### PR TITLE
Fix many crash bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@
 Makefile
 aclocal.m4
 autom4te.cache
-build-aux/ltmain.sh
+build-aux/
 cscope*

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,10 @@ AC_ARG_ENABLE(debug,
         [ --enable-debug turn on debug],
         CFLAGS="$CFLAGS -DGTKQQ_DEBUG -ggdb")
 
+AC_ARG_ENABLE(unity,
+        [ --enable-unity build on ubuntu unity],
+        CFLAGS="$CFLAGS -DUSE_UNITY")
+		
 #AC_ARG_ENABLE(libnotify,
 #              AS_HELP_STRING([--enable-libnotify],
 #                             [Enable libnotify support (used to show message\

--- a/src/gui/chatwidget.c
+++ b/src/gui/chatwidget.c
@@ -323,7 +323,13 @@ static void qq_chatwidget_init(QQChatWidget *widget)
     gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scrolled_win)
                                         , GTK_SHADOW_ETCHED_IN);
     gtk_container_add(GTK_CONTAINER(scrolled_win), priv -> input_textview);
-    gtk_box_pack_start(GTK_BOX(widget), scrolled_win, FALSE, FALSE, 0); 
+#ifndef USE_UNITY
+    gtk_box_pack_start(GTK_BOX(widget), scrolled_win, FALSE, FALSE, 0);
+#else
+	/* On ubuntu unity, there is a fuck bug if we pack the textview
+	 with the argument FALSE, FALSE, it cant be shown, how fuck it is. */
+	gtk_box_pack_start(GTK_BOX(widget), scrolled_win, TRUE, TRUE, 0);
+#endif	/* USE_UNITY */
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(priv -> input_textview)
                                                 , GTK_WRAP_CHAR);
 

--- a/src/libqq/qqlogin.c
+++ b/src/libqq/qqlogin.c
@@ -182,6 +182,12 @@ static gint get_vc_image(QQInfo *info)
 	res = rcv_response(con, &rps);
 	close_con(con);
 	connection_free(con);
+	
+	if (-1 == res || !rps) {
+		g_warning("Null point access (%s, %d)\n", __FILE__, __LINE__);
+		ret = -1;
+		goto error;
+	}
 	const gchar *retstatus = rps -> status -> str;
 	if(g_strstr_len(retstatus, -1, "200") == NULL){
 		g_warning("Server status %s (%s, %d)", retstatus

--- a/src/libqq/qqlogin.c
+++ b/src/libqq/qqlogin.c
@@ -44,16 +44,24 @@ static gint check_verify_code(QQInfo *info)
 {
 	g_debug("Check veriry code...(%s, %d)", __FILE__, __LINE__);
 	gint ret = 0;
-	gchar params[300];
+	gchar *params = NULL;
 
-	Request *req = request_new();
+	Request *req = NULL;
 	Response *rps = NULL;
 	int res = 0;
+
+	params = g_strdup_printf(VCCHECKPATH"?uin=%s&appid="APPID"&r=%.16f"
+							 , info -> me -> uin -> str, g_random_double());
+	if (!params)
+		return -1;
+	
+	req = request_new();
 	request_set_method(req, "GET");
 	request_set_version(req, "HTTP/1.1");
-	g_sprintf(params, VCCHECKPATH"?uin=%s&appid="APPID"&r=%.16f"
-			, info -> me -> uin -> str, g_random_double());
+
 	request_set_uri(req, params);
+	g_free(params);
+	
 	request_set_default_headers(req);
 	request_add_header(req, "Host", LOGINHOST);
 
@@ -156,16 +164,21 @@ static gint get_vc_image(QQInfo *info)
 		return PARAMETER_ERR;
 	}
 	gint ret = 0;
-	gchar params[500];
+	gint res = 0;
+	gchar *params = NULL;
 
+	params = g_strdup_printf(IMAGEPATH"?aid="APPID"&r=%.16f&uin=%s&vc_type=%s"
+							 , g_random_double(), info -> me -> uin -> str
+							 , info -> vc_type -> str);
+	if (!params)
+		return -1;
+	
 	Request *req = request_new();
 	Response *rps = NULL;
 	request_set_method(req, "GET");
 	request_set_version(req, "HTTP/1.1");
-	g_sprintf(params, IMAGEPATH"?aid="APPID"&r=%.16f&uin=%s&vc_type=%s"
-			, g_random_double(), info -> me -> uin -> str
-			, info -> vc_type -> str);
 	request_set_uri(req, params);
+	g_free(params);
 	request_set_default_headers(req);
 	request_add_header(req, "Host", IMAGEHOST);
 
@@ -178,7 +191,7 @@ static gint get_vc_image(QQInfo *info)
 	}
 
 	send_request(con, req);
-	rcv_response(con, &rps);
+	res = rcv_response(con, &rps);
 	close_con(con);
 	connection_free(con);
 	
@@ -293,7 +306,7 @@ error:
  */
 GString* get_pwvc_md5(const gchar *pwd, const gchar *vc, GError **err)
 {
-	guint8 buf[100];
+	guint8 buf[100] = {0};
 	gsize bsize = 100;
 	
 	GChecksum *cs = g_checksum_new(G_CHECKSUM_MD5);
@@ -310,8 +323,8 @@ GString* get_pwvc_md5(const gchar *pwd, const gchar *vc, GError **err)
 	g_checksum_update(cs, buf, bsize);
 	const gchar * md5_3 = g_checksum_get_string(cs);
 	md5_3 = g_ascii_strup(md5_3, strlen(md5_3));
-	gchar buf2[100];
-	g_sprintf(buf2, "%s%s", md5_3, vc);
+	gchar buf2[100] = {0};
+	g_snprintf(buf2, sizeof(buf2), "%s%s", md5_3, vc);
 	g_checksum_free(cs);
 
 	gchar *tmp1;
@@ -334,19 +347,24 @@ static gint get_ptcz_skey(QQInfo *info, const gchar *p)
 {
 	gint ret = 0;
 	gint res = 0;
-	gchar params[300];
+	gchar *params = NULL;
 
+	params = g_strdup_printf(LOGINPATH"?u=%s&p=%s&verifycode=%s&webqq_type=40&"
+							 "remember_uin=0&aid="APPID"&login2qq=1&u1=%s&h=1&"
+							 "ptredirect=0&ptlang=2052&from_ui=1&pttype=1"
+							 "&dumy=&fp=loginerroralert&action=4-30-764935&mibao_css=m_webqq"
+							 , info -> me -> uin -> str, p, info -> verify_code -> str
+							 , LOGIN_S_URL);
+	if (!params)
+		return -1;
+	
 	Request *req = request_new();
 	Response *rps = NULL;
 	request_set_method(req, "GET");
 	request_set_version(req, "HTTP/1.1");
-	g_sprintf(params, LOGINPATH"?u=%s&p=%s&verifycode=%s&webqq_type=40&"
-			"remember_uin=0&aid="APPID"&login2qq=1&u1=%s&h=1&"
-			"ptredirect=0&ptlang=2052&from_ui=1&pttype=1"
-			"&dumy=&fp=loginerroralert&action=4-30-764935&mibao_css=m_webqq"
-			, info -> me -> uin -> str, p, info -> verify_code -> str
-			, LOGIN_S_URL);
+	
 	request_set_uri(req, params);
+	g_free(params);
 	request_set_default_headers(req);
 	request_add_header(req, "Host", LOGINHOST);
 	request_add_header(req, "Referer", "http://ui.ptlogin2.qq.com/cgi-bin/"
@@ -355,9 +373,14 @@ static gint get_ptcz_skey(QQInfo *info, const gchar *p)
 						"om%2Floginproxy.html%3Flogin_level%3D3"
 						"&f_url=loginerroralert");
 	if(info -> ptvfsession != NULL){
-		g_sprintf(params, "ptvfsession=%s; "
-				, info -> ptvfsession -> str);
+		params = g_strdup_printf("ptvfsession=%s; "
+								 , info -> ptvfsession -> str);
+		if (!params) {
+			request_del(req);
+			return -1;
+		}
 		request_add_header(req, "Cookie", params);
+		g_free(params);
 	}
 
 	Connection *con = connect_to_host(LOGINHOST, 80);
@@ -482,8 +505,8 @@ static GString *generate_clientid()
 	g_get_current_time(&now);
 	glong t = now.tv_usec % 1000000;
 
-	gchar buf[20];
-	g_sprintf(buf, "%d%ld", (int)r, t);
+	gchar buf[20] = {0};
+	g_snprintf(buf, sizeof(buf), "%d%ld", (int)r, t);
 
 	return g_string_new(buf);
 }
@@ -528,8 +551,8 @@ static int get_psessionid(QQInfo *info)
 	g_free(escape);
 
 	request_append_msg(req, msg, strlen(msg));
-	gchar cl[10];
-	g_sprintf(cl, "%u", (unsigned int)strlen(msg));
+	gchar cl[10] = {0};
+	g_snprintf(cl, sizeof(cl), "%u", (unsigned int)strlen(msg));
 	request_add_header(req, "Content-Length", cl);
 	request_add_header(req, "Content-Type"
 			, "application/x-www-form-urlencoded");
@@ -751,15 +774,19 @@ static gint do_logout(QQInfo *info, GError **err)
 		return -1;
 	}
 
-	gchar params[300];
+	gchar *params = NULL;
+	params = g_strdup_printf(LOGOUTPATH"?clientid=%s&psessionid=%s&t=%ld"
+							 , info -> clientid -> str
+							 , info -> psessionid -> str, get_now_millisecond());
+	if (!params)
+		return -1;
+	
 	Request *req = request_new();
 	Response *rps = NULL;
 	request_set_method(req, "GET");
 	request_set_version(req, "HTTP/1.1");
-	g_sprintf(params, LOGOUTPATH"?clientid=%s&psessionid=%s&t=%ld"
-			, info -> clientid -> str
-			, info -> psessionid -> str, get_now_millisecond());
 	request_set_uri(req, params);
+	g_free(params);
 	request_set_default_headers(req);
 	request_add_header(req, "Host", LOGOUTHOST);
 	request_add_header(req, "Cookie", info -> cookie -> str);

--- a/src/libqq/qqtypes.c
+++ b/src/libqq/qqtypes.c
@@ -97,6 +97,11 @@ void qq_info_free(QQInfo *info)
 
 QQBuddy* qq_info_lookup_buddy_by_uin(QQInfo *info, const gchar *uin)
 {
+	if (!uin) {
+		g_warning("Null point access (%s, %d)\n", __FILE__, __LINE__);
+		return NULL;
+	}
+	
     QQBuddy *bdy = (QQBuddy*)g_hash_table_lookup(info -> buddies_ht, uin);
     if(bdy == NULL){
         gint i;
@@ -114,6 +119,11 @@ QQBuddy* qq_info_lookup_buddy_by_uin(QQInfo *info, const gchar *uin)
 }
 QQBuddy* qq_info_lookup_buddy_by_number(QQInfo *info, const gchar *number)
 {
+	if (!number) {
+		g_warning("Null point access (%s, %d)\n", __FILE__, __LINE__);
+		return NULL;
+	}
+	
     QQBuddy *bdy = (QQBuddy*)g_hash_table_lookup(info -> buddies_number_ht
                                                             , number);
     if(bdy == NULL){
@@ -134,6 +144,11 @@ QQBuddy* qq_info_lookup_buddy_by_number(QQInfo *info, const gchar *number)
 
 QQGroup* qq_info_lookup_group_by_code(QQInfo *info, const gchar *code)
 {
+	if (!code) {
+		g_warning("Null point access (%s, %d)\n", __FILE__, __LINE__);
+		return NULL;
+	}
+	
     QQGroup *grp = (QQGroup*)g_hash_table_lookup(info -> groups_ht, code);
     if(grp == NULL){
         gint i;
@@ -150,6 +165,10 @@ QQGroup* qq_info_lookup_group_by_code(QQInfo *info, const gchar *code)
 }
 QQGroup* qq_info_lookup_group_by_number(QQInfo *info, const gchar *number)
 {
+	if (!number) {
+		g_warning("Null point access (%s, %d)\n", __FILE__, __LINE__);
+		return NULL;
+	}
     QQGroup *grp = (QQGroup*)g_hash_table_lookup(info -> groups_ht, number);
     if(grp == NULL){
         gint i;


### PR DESCRIPTION
Fix some crash bug, see below.

Fix a fuck bug that occur in ubuntu unity only, so add --enable-unity to configure script if you build gtkqq in ubuntu unity.
#0  do_poll (data=<optimized out>) at qqpoll.c:318

318     gchar *retstatus = rps -> status -> str;
(gdb) bt
#0  do_poll (data=<optimized out>) at qqpoll.c:318
#1  0x00007ff2be5d04e6 in ?? () from /usr/lib64/libglib-2.0.so.0
#2  0x00007ff2bb3de2da in ?? () from /usr/lib64/libGL.so.1
#3  0x00007ff2bde91d0c in start_thread () from /lib64/libpthread.so.0
#4  0x00007ff2bdbd890d in clone () from /lib64/libc.so.6

*\* crash 2
warning: Can't read pathname for load map: 输入/输出错误.
[Thread debugging using libthread_db enabled]
Core was generated by `gtkqq'.
Program terminated with signal 11, Segmentation fault.
#0  0x00007f9e5475eb70 in g_str_hash () from /usr/lib64/libglib-2.0.so.0

(gdb) bt
#0  0x00007f9e5475eb70 in g_str_hash () from /usr/lib64/libglib-2.0.so.0
#1  0x00007f9e5472b693 in g_hash_table_lookup () from /usr/lib64/libglib-2.0.so.0
#2  0x00007f9e54e36321 in qq_info_lookup_group_by_code (info=0x87a360, code=0x0) at qqtypes.c:137
#3  0x000000000040eab6 in qq_group_chatwindow_update (win=0x894200) at groupchatwindow.c:169
#4  0x0000000000409a9e in gqq_ctx_callback (data=0xa60760) at msgloop.c:126
#5  0x00007f9e5473d092 in g_main_context_dispatch () from /usr/lib64/libglib-2.0.so.0
#6  0x00007f9e5473d888 in ?? () from /usr/lib64/libglib-2.0.so.0
#7  0x00007f9e5473ddda in g_main_loop_run () from /usr/lib64/libglib-2.0.so.0
#8  0x00007f9e57b6eec7 in gtk_main () from /usr/lib64/libgtk-x11-2.0.so.0
#9  0x00000000004099a8 in main (argc=1, argv=0x7fff077ddd38) at main.c:74

(gdb) 

*\* crash 3
(gdb) bt
#0  0x00007faf4dff29b9 in g_logv () from /usr/lib64/libglib-2.0.so.0
#1  0x00007faf4dff2d33 in g_log () from /usr/lib64/libglib-2.0.so.0
#2  0x00007faf4e6eec0d in get_authenticated_socket (host=<optimized out>, port=<optimized out>) at qqproxy.c:725
#3  0x00007faf4e6e04b3 in connect_to_host (hostname=<optimized out>, port=<optimized out>) at url.c:77
#4  0x00007faf4e6e7a00 in qq_get_qq_number (info=0x21f2360, uin=0x7faf40028e20 "3307224459", num=0x7faf3b45abb0 "", err=<optimized out>) at qqmanageinfo.c:60
#5  0x00000000004147ce in get_buddy_qqnumber_thread_func (data=<optimized out>) at loginpanel.c:542
#6  0x00007faf4e0114e6 in ?? () from /usr/lib64/libglib-2.0.so.0
#7  0x00007faf4ae1f2da in ?? () from /usr/lib64/libGL.so.1
#8  0x00007faf4d8d2d0c in start_thread () from /lib64/libpthread.so.0
#9  0x00007faf4d61990d in clone () from /lib64/libc.so.6
