### PR TITLE
Add a option whether enable proxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,10 @@ AC_ARG_ENABLE(debug,
 AC_ARG_ENABLE(unity,
         [ --enable-unity build on ubuntu unity],
         CFLAGS="$CFLAGS -DUSE_UNITY")
+
+AC_ARG_ENABLE(proxy,
+        [ --enable-proxy build on ubuntu unity],
+        CFLAGS="$CFLAGS -DUSE_PROXY")		
 		
 #AC_ARG_ENABLE(libnotify,
 #              AS_HELP_STRING([--enable-libnotify],

--- a/src/gui/loginpanel.c
+++ b/src/gui/loginpanel.c
@@ -8,7 +8,9 @@
 #include <msgloop.h>
 #include <msgdispacher.h>
 #include <string.h>
+#ifdef USE_PROXY
 #include <proxypanel.h>
+#endif	/* USE_PROXY */
 /*
  * The global value
  * in main.c
@@ -427,11 +429,13 @@ static void qq_loginpanel_init(QQLoginPanel *obj)
         usr = (GQQLoginUser*)g_ptr_array_index(login_users, 0);
         qq_statusbutton_set_status_string(obj -> status_comb, usr -> status);
     }
+#ifdef USE_PROXY
     //proxy setting
     obj -> set_proxy_btn = gtk_button_new_with_label("Network");
     gtk_widget_set_size_request(obj -> set_proxy_btn, 100, -1);
     g_signal_connect(G_OBJECT(obj -> set_proxy_btn), "clicked"
                      , G_CALLBACK(set_proxy_btn_cb), (gpointer)obj);
+#endif	/* USE_PROXY */
     
     GtkWidget *hbox1 = gtk_hbox_new(FALSE, 0);
     gtk_box_pack_start(GTK_BOX(hbox1), vbox, TRUE, FALSE, 0);
@@ -442,9 +446,12 @@ static void qq_loginpanel_init(QQLoginPanel *obj)
     gtk_box_pack_start(GTK_BOX(hbox2), obj -> login_btn, FALSE, FALSE, 0);
     gtk_box_pack_start(GTK_BOX(hbox3), hbox2, TRUE, FALSE, 0);
 
+#ifdef USE_PROXY
     GtkWidget *hbox_proxy_setting = gtk_hbutton_box_new();
     gtk_button_box_set_layout(GTK_BUTTON_BOX(hbox_proxy_setting), GTK_BUTTONBOX_CENTER);
     gtk_box_pack_start(GTK_BOX(hbox_proxy_setting), obj -> set_proxy_btn, FALSE, FALSE, 0);
+#endif	/* USE_PROXY */
+	
     //error informatin label
     obj -> err_label = gtk_label_new("");
     GdkColor color;
@@ -459,8 +466,10 @@ static void qq_loginpanel_init(QQLoginPanel *obj)
     gtk_box_pack_start(GTK_BOX(vbox), hbox2, TRUE, FALSE, 0);
 
     gtk_box_pack_start(GTK_BOX(vbox), hbox3, FALSE, FALSE, 0);
-    
+
+#ifdef USE_PROXY
     gtk_box_pack_start(GTK_BOX(vbox), hbox_proxy_setting, TRUE, TRUE, 10);
+#endif	/* USE_PROXY */
     
     gtk_box_set_homogeneous(GTK_BOX(obj), FALSE);
     GtkWidget *logo = gtk_image_new_from_file(IMGDIR"webqq_icon.png");

--- a/src/gui/loginpanel.h
+++ b/src/gui/loginpanel.h
@@ -37,7 +37,10 @@ struct _QQLoginPanel{
     GtkWidget *passwd_label, *passwd_entry;
     GtkWidget *rempwcb;             //rember password check button
     GtkWidget *err_label;           //show error infomation.
-    GtkWidget *login_btn, *status_comb, *set_proxy_btn;
+    GtkWidget *login_btn, *status_comb;
+#ifdef USE_PROXY
+	GtkWidget *set_proxy_btn;
+#endif	/* USE_PROXY */
 
     const gchar *uin, *passwd, *status;
 	gint rempw;


### PR DESCRIPTION
App exit when connect host fail? 

In configure.ad file , i add a option to decide whether enable proxy feature.  I think it will be better.

Program terminated with signal 5, Trace/breakpoint trap.
#0  0x00007f31d0b049b9 in g_logv () from /usr/lib64/libglib-2.0.so.0

(gdb) bt
#0  0x00007f31d0b049b9 in g_logv () from /usr/lib64/libglib-2.0.so.0
#1  0x00007f31d0b04d33 in g_log () from /usr/lib64/libglib-2.0.so.0
#2  0x00007f31d1200d6d in get_authenticated_socket (host=<optimized out>, port=<optimized out>) at qqproxy.c:725
#3  0x00007f31d11f2513 in connect_to_host (hostname=<optimized out>, port=<optimized out>) at url.c:77
#4  0x00007f31d11f9b60 in qq_get_qq_number (info=0x1c72360, uin=0x7f31c0080710 "461962719", num=0x7f31bc9e6bb0 "417729624", err=<optimized out>) at qqmanageinfo.c:60
#5  0x000000000041481e in get_buddy_qqnumber_thread_func (data=<optimized out>) at loginpanel.c:542
#6  0x00007f31d0b234e6 in ?? () from /usr/lib64/libglib-2.0.so.0
#7  0x00007f31cd9312da in ?? () from /usr/lib64/libGL.so.1
#8  0x00007f31d03e4d0c in start_thread () from /lib64/libpthread.so.0
#9  0x00007f31d012b90d in clone () from /lib64/libc.so.6
