### PR TITLE
trayicon popup menu add position handle

### DIFF
--- a/src/gui/tray.c
+++ b/src/gui/tray.c
@@ -89,8 +89,10 @@ static void qq_tray_popup_menu(GtkStatusIcon *tray, guint button
 {
     QQTrayPriv *priv = G_TYPE_INSTANCE_GET_PRIVATE(tray, qq_tray_get_type()
                                                     , QQTrayPriv);
-    gtk_menu_popup(GTK_MENU(priv -> popupmenu), NULL, NULL, NULL
-                            , NULL, button, active_time);
+    gtk_menu_popup(GTK_MENU(priv -> popupmenu),
+                   NULL, NULL,
+                   gtk_status_icon_position_menu, tray, 
+                   button, active_time);
 }
 
 static gboolean qq_tray_button_press(GtkStatusIcon *tray, GdkEvent *event


### PR DESCRIPTION
in gnome-shell status bar, the popup menu if not set `GtkMenuPositionFunc` function, some menu item will under the status bar...

http://developer.gnome.org/gtk/2.24/GtkMenu.html#GtkMenuPositionFunc

GtkStatusIcon use gtk_status_icon_position_menu function handle it...
