### PR TITLE
增加rpm打包配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-*.in
+Makefile.in
 *.lo
 *.log
 *.o

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,11 @@
 SUBDIRS= src pixmaps
 ACLOCAL_AMFLAGS = -I m4
+
+rpm: dist
+	mkdir -p rpmbuild
+	cp ${PACKAGE}-${VERSION}.tar.gz rpmbuild
+	rpmbuild --define "_sourcedir `pwd`/rpmbuild" \
+		--define "_srcrpmdir `pwd`/rpmbuild" \
+		--define "_builddir `pwd`/rpmbuild" \
+		--define "_rpmdir `pwd`/rpmbuild" \
+		-ba ${PACKAGE}.spec

--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,7 @@ AC_CHECK_FUNCS([bzero gethostbyname memset mkdir select socket strstr strtol])
 AC_CHECK_FUNCS([inet_ntoa])
 
 AC_CONFIG_FILES([Makefile
+	 gtkqq.spec
          src/Makefile 
          src/comm/Makefile 
          src/libqq/Makefile 

--- a/gtkqq.spec.in
+++ b/gtkqq.spec.in
@@ -1,0 +1,100 @@
+%if 0%{?suse_version}  
+%define		pkgconfig	pkg-config
+%define 	sqlite		sqlite3
+%define 	sqlite_devel	sqlite3-devel
+%define		gstreamer_devel	gstreamer-0_10-devel
+%define		group		Productivity/Networking/Instant Messenger
+%else
+%define		pkgconfig	pkgconfig
+%define 	sqlite		sqlite
+%define 	sqlite_devel	sqlite-devel
+%define		gstreamer_devel	gstreamer-devel
+%define		group		Productivity/Networking
+%endif
+
+Name:		@PACKAGE@
+Version:	@VERSION@
+Release:	1%{?dist}%{?extra_release}
+Summary:	A Gtk QQ client
+
+Group:		%{group}
+License:	GPL
+URL:		https://github.com/kernelhcy/gtkqq
+Source0:	%{name}-%{version}.tar.gz
+BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
+
+BuildRequires:	%{pkgconfig}
+BuildRequires:	zlib-devel
+BuildRequires:	glib2-devel
+BuildRequires:	gtk2-devel >= 2.24.0
+BuildRequires:	%{sqlite_devel} >= 3.7.0
+BuildRequires:	%{gstreamer_devel} >= 0.10.0
+%if 0%{?suse_version}  
+BuildRequires:	update-desktop-files
+%endif
+Requires:	libwebqq = %{version}
+
+%description
+GtkQQ is a QQ client. It is written using gtk and based on the webqq protocol.
+
+The webqq protocol is based on the HTTP. 
+Visit http://web.qq.com to see it.
+
+Maybe GtkQQ is a browser, whick can only visit http://web.qq.com.
+I think there is no copyright problem, because I just write a highly custommed
+broswer.
+
+%package -n 	libwebqq
+License:	GPL
+Group:		System/Libraries
+Requires:	gtk2 >= 2.24
+Requires:	%{sqlite}
+Summary:	Library for GtkQQ
+
+%description -n libwebqq
+GtkQQ is a QQ client. It is written using gtk and based on the webqq protocol.
+
+This packages provides the library required for gtkqq.
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+./configure --prefix=%{_prefix} --libdir=%{_libdir}
+make %{?_smp_mflags}
+
+%install
+make install DESTDIR=%{buildroot}
+# buggy, not sure the purpose of it
+rm -f %{buildroot}/%{_bindir}/qq
+# don't need these files, unless a devel package is added
+rm -f %{buildroot}/%{_libdir}/libwebqq.so
+rm -f %{buildroot}/%{_libdir}/libwebqq.la
+rm -f %{buildroot}/%{_libdir}/libwebqq.a
+%if 0%{?suse_version}  
+%suse_update_desktop_file    gtkqq	GNOME GTK Network InstantMessaging
+%endif
+
+%clean
+rm -rf %{buildroot}
+
+%post -n libwebqq -p /sbin/ldconfig
+
+%postun -n libwebqq -p /sbin/ldconfig
+
+%files -n libwebqq
+%defattr(-,root,root,-)
+%{_libdir}/libwebqq.so.*
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/gtkqq
+%dir %{_datadir}/gtkqq
+%{_datadir}/gtkqq/*
+%{_datadir}/applications/gtkqq.desktop
+%{_datadir}/pixmaps/gtkqq.png
+
+%changelog
+* Sun Jan 15 2012 Lyre <lyre@poetpalace.org> - 0.1-1
+- Initial rpm packages.

--- a/src/gui/test/Makefile.am
+++ b/src/gui/test/Makefile.am
@@ -1,4 +1,4 @@
-bin_PROGRAMS=winmove
+noinst_PROGRAMS=winmove
 winmove_CPPFLAGS= -I$(srcdir)/. $(GTK_CFLAGS) -g -Wall -O2
 winmove_LDADD = $(GTK_LIBS)
 

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -3,7 +3,7 @@ AM_CFLAGS+=-I${srcdir}/../comm/
 AM_CFLAGS+=-I${srcdir}/../gui/
 AM_CFLAGS+=${GLIB_CFLAGS} -DGTKQQ_DEBUG -Wall -Werror
 
-bin_PROGRAMS=testhttp testjson testcprint testlog testurl testpro testproxy
+noinst_PROGRAMS=testhttp testjson testcprint testlog testurl testpro testproxy
 
 testhttp_SOURCES= testhttp.c
 testhttp_LDADD=${srcdir}/../libqq/libwebqq.la $(GLIB_LIBS)


### PR DESCRIPTION
你好：
    这几个补丁主要增加了构建rpm包需要的修改。

```
第一个补丁防止 make install的时候把测试程序也装上；
第二个补丁增加了spec文件的模板，同时修改了.gitignore。为了日后方便维护，我拆成了libwebqq和gtkqq两个包。其中/usr/bin/qq 在我这里运行起来不太正常，也不太清楚是干什么的，所以没有包含到rpm里面；
第三个补丁增加了一个make rpm的命令，在当前目录的rpmbuild下生成rpm包，仅仅是为了方便。
```

以上修改已经在openSUSE Build Service 上进行了测试，可以在这里找到：

https://build.opensuse.org/package/show?package=gtkqq&project=home%3Amidmay%3Apackages
