### PR TITLE
Dev

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,11 +43,11 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdint.h\
           stdlib.h string.h sys/ioctl.h sys/socket.h unistd.h zlib.h])
 
 AC_ARG_ENABLE(unity,
-        [ --enable-unity build on ubuntu unity],
+        [AS_HELP_STRING([--enable-unity], [build on ubuntu unity])],
         CFLAGS="$CFLAGS -DUSE_UNITY")
 
 AC_ARG_ENABLE(proxy,
-        [ --enable-proxy build on ubuntu unity],
+        [AS_HELP_STRING([--enable-proxy], [build on ubuntu unity])],
         CFLAGS="$CFLAGS -DUSE_PROXY")		
 		
 #AC_ARG_ENABLE(libnotify,

--- a/src/gui/chattextview.h
+++ b/src/gui/chattextview.h
@@ -25,13 +25,13 @@
 // ------------------------------------------
 //
 
-#define QQ_CHAT_TEXTVIEW(obj)	    GTK_CHECK_CAST(obj\
+#define QQ_CHAT_TEXTVIEW(obj)	    G_TYPE_CHECK_INSTANCE_CAST(obj\
                                                 , qq_chat_textview_get_type()\
 						                        , QQChatTextview)
-#define QQ_CHAT_TEXTVIEWCLASS(c)	GTK_CHECK_CLASS_CAST(c\
+#define QQ_CHAT_TEXTVIEWCLASS(c)	G_TYPE_CHECK_CLASS_CAST(c\
 						                        , qq_chat_textview_get_type()\
 						                        , QQChatTextviewClass)
-#define QQ_IS_CHAT_TEXTVIEW(obj)	GTK_CHECK_TYPE(obj\
+#define QQ_IS_CHAT_TEXTVIEW(obj)	G_TYPE_CHECK_INSTANCE_TYPE(obj\
                                                 , qq_chat_textview_get_type())
 
 typedef struct __QQChatTextview 		QQChatTextview;

--- a/src/gui/chatwidget.h
+++ b/src/gui/chatwidget.h
@@ -25,12 +25,12 @@
 // |                                            |
 // ----------------------------------------------
 //
-#define QQ_CHATWIDGET(obj)      GTK_CHECK_CAST(obj, qq_chatwidget_get_type()\
+#define QQ_CHATWIDGET(obj)      G_TYPE_CHECK_INSTANCE_CAST(obj, qq_chatwidget_get_type()\
                                                 , QQChatWidget)
-#define QQ_CHATWIDGETCLASS(c)   GTK_CHECK_CLASS_CAST(c\
+#define QQ_CHATWIDGETCLASS(c)   G_TYPE_CHECK_CLASS_CAST(c\
                                                 , qq_chatwidget_get_type()\
                                                 , QQChatWidgetClass)
-#define QQ_IS_CHATWIDGET(obj)   GTK_CHECK_TYPE(obj, qq_chatwidget_get_type())
+#define QQ_IS_CHATWIDGET(obj)   G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_chatwidget_get_type())
 
 typedef struct __QQChatWidget         QQChatWidget;
 typedef struct __QQChatWidgetClass    QQChatWidgetClass;

--- a/src/gui/chatwindow.h
+++ b/src/gui/chatwindow.h
@@ -3,12 +3,12 @@
 #include <gtk/gtk.h>
 #include <qq.h>
 
-#define QQ_CHATWINDOW(obj)      GTK_CHECK_CAST(obj, qq_chatwindow_get_type()\
+#define QQ_CHATWINDOW(obj)      G_TYPE_CHECK_INSTANCE_CAST(obj, qq_chatwindow_get_type()\
                                                 , QQChatWindow)
-#define QQ_CHATWINDOWCLASS(c)   GTK_CHECK_CLASS_CAST(c\
+#define QQ_CHATWINDOWCLASS(c)   G_TYPE_CHECK_CLASS_CAST(c\
                                                 , qq_chatwindow_get_type()\
                                                 , QQChatWindowClass)
-#define QQ_IS_CHATWINDOW(obj)   GTK_CHECK_TYPE(obj, qq_chatwindow_get_type())
+#define QQ_IS_CHATWINDOW(obj)   G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_chatwindow_get_type())
 
 typedef struct __QQChatWindow         QQChatWindow;
 typedef struct __QQChatWindowClass    QQChatWindowClass;

--- a/src/gui/facepopupwindow.h
+++ b/src/gui/facepopupwindow.h
@@ -5,13 +5,13 @@
 #include <qq.h>
 
 #define QQ_TYPE_FACE_POPUP_WINDOW       qq_face_popup_window_get_type()
-#define QQ_FACE_POPUP_WINDOW(obj)	    GTK_CHECK_CAST(obj\
+#define QQ_FACE_POPUP_WINDOW(obj)	    G_TYPE_CHECK_INSTANCE_CAST(obj\
                                                 , QQ_TYPE_FACE_POPUP_WINDOW\
 						                        , QQFacePopupWindow)
-#define QQ_FACE_POPUP_WINDOWCLASS(c)	GTK_CHECK_CLASS_CAST(c\
+#define QQ_FACE_POPUP_WINDOWCLASS(c)	G_TYPE_CHECK_CLASS_CAST(c\
 						                        , QQ_TYPE_FACE_POPUP_WINDOW\
 						                        , QQFacePopupWindowClass)
-#define QQ_IS_FACE_POPUP_WINDOW(obj)	GTK_CHECK_TYPE(obj\
+#define QQ_IS_FACE_POPUP_WINDOW(obj)	G_TYPE_CHECK_INSTANCE_TYPE(obj\
                                                 , QQ_TYPE_FACE_POPUP_WINDOW)
 
 typedef struct __QQFacePopupWindow 		QQFacePopupWindow;

--- a/src/gui/groupchatwindow.h
+++ b/src/gui/groupchatwindow.h
@@ -4,13 +4,13 @@
 #include <qq.h>
 
 #define QQ_TYPE_GROUP_CHATWINDOW        qq_group_chatwindow_get_type()
-#define QQ_GROUP_CHATWINDOW(obj)        GTK_CHECK_CAST(obj\
+#define QQ_GROUP_CHATWINDOW(obj)        G_TYPE_CHECK_INSTANCE_CAST(obj\
                                                 , QQ_TYPE_GROUP_CHATWINDOW\
                                                 , QQGroupChatWindow)
-#define QQ_GROUP_CHATWINDOWCLASS(c)     GTK_CHECK_CLASS_CAST(c\
+#define QQ_GROUP_CHATWINDOWCLASS(c)     G_TYPE_CHECK_CLASS_CAST(c\
                                                 , QQ_TYPE_GROUP_CHATWINDOW()\
                                                 , QQGroupChatWindowClass)
-#define QQ_IS_GROUP_CHATWINDOW(obj)     GTK_CHECK_TYPE(obj\
+#define QQ_IS_GROUP_CHATWINDOW(obj)     G_TYPE_CHECK_INSTANCE_TYPE(obj\
                                                 , QQ_TYPE_GROUP_CHATWINDOW())
 
 typedef struct __QQGroupChatWindow         QQGroupChatWindow;

--- a/src/gui/loginpanel.c
+++ b/src/gui/loginpanel.c
@@ -40,7 +40,7 @@ static GQQMessageLoop gtkloop;
 
 static GPtrArray* login_users = NULL;
 
-GtkType qq_loginpanel_get_type()
+GType qq_loginpanel_get_type()
 {
     static GType t = 0;
     if(!t){

--- a/src/gui/loginpanel.h
+++ b/src/gui/loginpanel.h
@@ -2,12 +2,12 @@
 #define __GTKQQ_LOGINWIN_H
 #include <gtk/gtk.h>
 
-#define QQ_LOGINPANEL(obj)    GTK_CHECK_CAST(obj, qq_loginpanel_get_type()\
+#define QQ_LOGINPANEL(obj)    G_TYPE_CHECK_INSTANCE_CAST(obj, qq_loginpanel_get_type()\
                                         , QQLoginPanel)
-#define QQ_LOGINPANEL_CLASS(c)    GTK_CHECK_CLASS_CAST(c\
+#define QQ_LOGINPANEL_CLASS(c)    G_TYPE_CHECK_CLASS_CAST(c\
                                         , qq_loginpanel_get_type()\
                                         , QQLoginPanelClass)
-#define QQ_IS_LOGINPANEL(obj)    GTK_CHECK_TYPE(obj, qq_loginpanel_get_type())
+#define QQ_IS_LOGINPANEL(obj)    G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_loginpanel_get_type())
 
 typedef struct _QQLoginPanel            QQLoginPanel;
 typedef struct _QQLoginPanelClass       QQLoginPanelClass;
@@ -62,7 +62,7 @@ struct _QQLoginPanelClass{
  *     set to NULL.
  */
 GtkWidget* qq_loginpanel_new(GtkWidget *container);
-GtkType qq_loginpanel_get_type();
+GType qq_loginpanel_get_type();
 
 /*
  * Get the inputs

--- a/src/gui/mainpanel.h
+++ b/src/gui/mainpanel.h
@@ -2,12 +2,12 @@
 #define __GTKQQ_MAINPANEL_H
 #include <gtk/gtk.h>
 
-#define QQ_MAINPANEL(obj)       GTK_CHECK_CAST(obj, qq_mainpanel_get_type()\
+#define QQ_MAINPANEL(obj)       G_TYPE_CHECK_INSTANCE_CAST(obj, qq_mainpanel_get_type()\
                                             , QQMainPanel)
-#define QQ_MAINPANELCLASS(c)    GTK_CHECK_CLASS_CAST(c\
+#define QQ_MAINPANELCLASS(c)    G_TYPE_CHECK_CLASS_CAST(c\
                                             , qq_mainpanel_get_type()\
                                             , QQMainPanelClass)
-#define QQ_IS_MAINPANEL(obj)    GTK_CHECK_TYPE(obj, qq_mainpanel_get_type())
+#define QQ_IS_MAINPANEL(obj)    G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_mainpanel_get_type())
 
 typedef struct _QQMainPanel         QQMainPanel;
 typedef struct _QQMainPanelClass    QQMainPanelClass;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -2,12 +2,12 @@
 #define __GTKQQ_MAINWINDOW_H
 #include <gtk/gtk.h>
 
-#define QQ_MAINWINDOW(obj)	GTK_CHECK_CAST(obj, qq_mainwindow_get_type()\
+#define QQ_MAINWINDOW(obj)	G_TYPE_CHECK_INSTANCE_CAST(obj, qq_mainwindow_get_type()\
 						, QQMainWindow)
-#define QQ_MAINWINDOWCLASS(c)	GTK_CHECK_CLASS_CAST(c\
+#define QQ_MAINWINDOWCLASS(c)	G_TYPE_CHECK_CLASS_CAST(c\
 						, qq_mainwindow_get_type()\
 						, QQMainWindowClass)
-#define QQ_IS_MAINWINDOW(obj)	GTK_CHECK_TYPE(obj, qq_mainwindow_get_type())
+#define QQ_IS_MAINWINDOW(obj)	G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_mainwindow_get_type())
 
 typedef struct __QQMainWindow 		QQMainWindow;
 typedef struct __QQMainWindowClass	QQMainWindowClass;

--- a/src/gui/splashpanel.h
+++ b/src/gui/splashpanel.h
@@ -2,12 +2,12 @@
 #define __GTKQQ_SPLASHPANEL_H
 #include <gtk/gtk.h>
 
-#define QQ_SPLASHPANEL(obj)	GTK_CHECK_CAST(obj, qq_splashpanel_get_type(),\
+#define QQ_SPLASHPANEL(obj)	G_TYPE_CHECK_INSTANCE_CAST(obj, qq_splashpanel_get_type(),\
 						QQSplashPanel)
-#define QQ_SPLASHPANEL_CLASS(c)	GTK_CHECK_CLASS_CAST(c,\
+#define QQ_SPLASHPANEL_CLASS(c)	G_TYPE_CHECK_CLASS_CAST(c,\
 						qq_splashpanel_get_type(),\
 						QQSplashPanelClass)
-#define QQ_IS_SPLASHPANEL(obj)	GTK_CHECK_TYPE(obj, qq_splashPanel_get_type())
+#define QQ_IS_SPLASHPANEL(obj)	G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_splashPanel_get_type())
 
 typedef struct _QQSplashPanel 		QQSplashPanel;
 typedef struct _QQSplashPanelClass	QQSplashPanelClass;
@@ -21,6 +21,6 @@ struct _QQSplashPanelClass{
 };
 
 GtkWidget *qq_splashpanel_new();
-GtkType qq_splashpanel_get_type();
+GType qq_splashpanel_get_type();
 
 #endif

--- a/src/gui/statusbutton.h
+++ b/src/gui/statusbutton.h
@@ -7,13 +7,13 @@
  * QQ status button.
  * Show and change the status.
  */
-#define QQ_STATUSBUTTON(obj) 		GTK_CHECK_CAST(obj\
+#define QQ_STATUSBUTTON(obj) 		G_TYPE_CHECK_INSTANCE_CAST(obj\
 						, qq_statusbutton_get_type()\
 						, QQStatusButton)
-#define QQ_STATUSBUTTONCLASS(c)		GTK_CHECK_CLASS_CAST(c\
+#define QQ_STATUSBUTTONCLASS(c)		G_TYPE_CHECK_CLASS_CAST(c\
 						, qq_statusbutton_get_type()\
 						, QQStatusButtonClass)
-#define QQ_IS_STATUSBUTTON(obj) 	GTK_CHECK_TYPE(obj\
+#define QQ_IS_STATUSBUTTON(obj) 	G_TYPE_CHECK_INSTANCE_TYPE(obj\
 						, qq_statusbutton_get_type())
 #define QQ_TYPE_STATUSBUTTON 		qq_statusbutton_get_type()
 

--- a/src/gui/tray.h
+++ b/src/gui/tray.h
@@ -3,10 +3,10 @@
 #include <gtk/gtk.h>
 #include <qq.h>
 
-#define QQ_TRAY(obj)	GTK_CHECK_CAST(obj, qq_tray_get_type(), QQTray)
-#define QQ_TRAYCLASS(c)	GTK_CHECK_CLASS_CAST(c, qq_tray_get_type()\
+#define QQ_TRAY(obj)	G_TYPE_CHECK_INSTANCE_CAST(obj, qq_tray_get_type(), QQTray)
+#define QQ_TRAYCLASS(c)	G_TYPE_CHECK_CLASS_CAST(c, qq_tray_get_type()\
 						                    , QQTrayClass)
-#define QQ_IS_TRAY(obj)	GTK_CHECK_TYPE(obj, qq_tray_get_type())
+#define QQ_IS_TRAY(obj)	G_TYPE_CHECK_INSTANCE_TYPE(obj, qq_tray_get_type())
 
 typedef struct __QQTray 		QQTray;
 typedef struct __QQTrayClass	QQTrayClass;


### PR DESCRIPTION
修正新版本GTK+兼容性问题
GTK后续版本取消了 GTK_CHECK_CAST GTK_CHECK_CLASS_CAST GTK_CHECK_TYPE
希望直接使用gobject 里的 定义
# define GTK_CHECK_CAST G_TYPE_CHECK_INSTANCE_CAST
# define GTK_CHECK_CLASS_CAST G_TYPE_CHECK_CLASS_CAST
# define GTK_CHECK_TYPE G_TYPE_CHECK_INSTANCE_TYPE
